### PR TITLE
fix where and filter argument usage

### DIFF
--- a/flume/adapters/elastic/node.py
+++ b/flume/adapters/elastic/node.py
@@ -8,7 +8,7 @@ from elasticsearch import Elasticsearch, helpers
 
 from flume import logger, moment
 from flume.adapters.adapter import adapter
-from flume.adapters.elastic.query import where_to_es_query
+from flume.adapters.elastic.query import filter_to_es_query
 from flume.exceptions import FlumineException
 from flume.point import Point
 
@@ -26,14 +26,14 @@ class elastic(adapter):
                  host='localhost',
                  port=9200,
                  time='time',
-                 where=None,
+                 filter=None,
                  batch=1024):
         self.index = index
         self.type = type
         self.host = host
         self.port = port
         self.time = time
-        self.where = where
+        self.filter = filter
         self.batch = batch
         self.clients = {}
 
@@ -55,7 +55,7 @@ class elastic(adapter):
         points = []
         client = self._get_elasticsearch(self.host, self.port)
 
-        query = where_to_es_query(self.where)
+        query = filter_to_es_query(self.filter)
         logger.debug('es query %s' % json.dumps(query))
 
         for result in helpers.scan(client,

--- a/flume/adapters/elastic/query.py
+++ b/flume/adapters/elastic/query.py
@@ -84,17 +84,17 @@ def to_es_query(node):
 
     raise Exception('unhandled %s' % node)
 
-def where_to_es_query(where_expr):
+def filter_to_es_query(filter_expr):
     """
     take a filter expression such as `foo=="bar"` and convert it into
     the corresponding ES query
     """
-    if where_expr is None:
+    if filter_expr is None:
         return {'match_all': {}}
     else:
         try:
-            tree = ast.parse(where_expr)
+            tree = ast.parse(filter_expr)
             return {'constant_score': to_es_query(tree)}
         except Exception as exception:
-            raise FlumineException('invalid where expression: %s - %s' %
-                                   (where_expr, exception))
+            raise FlumineException('invalid filter expression: %s - %s' %
+                                   (filter_expr, exception))

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def load(filename):
 
 setup(
     name='flume',
-    version='0.1',
+    version='0.2',
     author='Rodney Gomes',
     author_email='rodneygomes@gmail.com',
     url='',

--- a/test/integration/adapters/elastic/test_elastic.py
+++ b/test/integration/adapters/elastic/test_elastic.py
@@ -61,7 +61,7 @@ class ElasticTest(unittest.TestCase):
             (
                 read('elastic',
                      index='bananas',
-                     where='foo=="bananas"')
+                     filter='foo=="bananas"')
             ).execute()
         except Exception as exception:
             expect(str(exception)).to.contain('no such index')
@@ -72,7 +72,7 @@ class ElasticTest(unittest.TestCase):
         (
             read('elastic',
                  index='test_data',
-                 where='foo=="bananas"')
+                 filter='foo=="bananas"')
             | memory(results)
         ).execute()
 
@@ -84,7 +84,7 @@ class ElasticTest(unittest.TestCase):
         (
             read('elastic',
                  index='test_data',
-                 where='integer > 0',
+                 filter='integer > 0',
                  batch=2)
             | memory(results)
         ).execute()
@@ -93,7 +93,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_filter_eq_string(self):
         results = []
         (
-            read('elastic', index='test_data', where='string == "h"')
+            read('elastic', index='test_data', filter='string == "h"')
             | memory(results)
         ).execute()
 
@@ -104,7 +104,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_filter_eq_integer(self):
         results = []
         (
-            read('elastic', index='test_data', where='integer == 8')
+            read('elastic', index='test_data', filter='integer == 8')
             | memory(results)
         ).execute()
 
@@ -115,7 +115,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_filter_eq_float(self):
         results = []
         (
-            read('elastic', index='test_data', where='float == 8.0')
+            read('elastic', index='test_data', filter='float == 8.0')
             | memory(results)
         ).execute()
 
@@ -126,7 +126,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_filter_neq_string(self):
         results = []
         (
-            read('elastic', index='test_data', where='string != "h"')
+            read('elastic', index='test_data', filter='string != "h"')
             | memory(results)
         ).execute()
 
@@ -145,7 +145,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_filter_neq_integer(self):
         results = []
         (
-            read('elastic', index='test_data', where='integer != 8')
+            read('elastic', index='test_data', filter='integer != 8')
             | memory(results)
         ).execute()
 
@@ -164,7 +164,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_filter_neq_float(self):
         results = []
         (
-            read('elastic', index='test_data', where='float != 8.0')
+            read('elastic', index='test_data', filter='float != 8.0')
             | memory(results)
         ).execute()
 
@@ -183,7 +183,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_filter_gt_string(self):
         results = []
         (
-            read('elastic', index='test_data', where='string > "g"')
+            read('elastic', index='test_data', filter='string > "g"')
             | memory(results)
         ).execute()
 
@@ -196,7 +196,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_filter_gt_integer(self):
         results = []
         (
-            read('elastic', index='test_data', where='integer > 7')
+            read('elastic', index='test_data', filter='integer > 7')
             | memory(results)
         ).execute()
 
@@ -209,7 +209,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_filter_gt_float(self):
         results = []
         (
-            read('elastic', index='test_data', where='float > 7.0')
+            read('elastic', index='test_data', filter='float > 7.0')
             | memory(results)
         ).execute()
 
@@ -222,7 +222,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_filter_gte_string(self):
         results = []
         (
-            read('elastic', index='test_data', where='string >= "h"')
+            read('elastic', index='test_data', filter='string >= "h"')
             | memory(results)
         ).execute()
 
@@ -235,7 +235,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_filter_gte_integer(self):
         results = []
         (
-            read('elastic', index='test_data', where='integer >= 8')
+            read('elastic', index='test_data', filter='integer >= 8')
             | memory(results)
         ).execute()
 
@@ -248,7 +248,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_filter_gte_float(self):
         results = []
         (
-            read('elastic', index='test_data', where='float >= 8.0')
+            read('elastic', index='test_data', filter='float >= 8.0')
             | memory(results)
         ).execute()
 
@@ -261,7 +261,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_filter_lt_string(self):
         results = []
         (
-            read('elastic', index='test_data', where='string < "d"')
+            read('elastic', index='test_data', filter='string < "d"')
             | memory(results)
         ).execute()
 
@@ -274,7 +274,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_filter_lt_integer(self):
         results = []
         (
-            read('elastic', index='test_data', where='integer < 4')
+            read('elastic', index='test_data', filter='integer < 4')
             | memory(results)
         ).execute()
 
@@ -287,7 +287,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_filter_lt_float(self):
         results = []
         (
-            read('elastic', index='test_data', where='float < 4.0')
+            read('elastic', index='test_data', filter='float < 4.0')
             | memory(results)
         ).execute()
 
@@ -300,7 +300,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_filter_lte_string(self):
         results = []
         (
-            read('elastic', index='test_data', where='string <= "c"')
+            read('elastic', index='test_data', filter='string <= "c"')
             | memory(results)
         ).execute()
 
@@ -313,7 +313,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_filter_lte_integer(self):
         results = []
         (
-            read('elastic', index='test_data', where='integer <= 3')
+            read('elastic', index='test_data', filter='integer <= 3')
             | memory(results)
         ).execute()
 
@@ -326,7 +326,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_filter_lte_float(self):
         results = []
         (
-            read('elastic', index='test_data', where='float <= 3.0')
+            read('elastic', index='test_data', filter='float <= 3.0')
             | memory(results)
         ).execute()
 
@@ -339,7 +339,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_and_filter(self):
         results = []
         (
-            read('elastic', index='test_data', where='string == "a" and float == 1.0')
+            read('elastic', index='test_data', filter='string == "a" and float == 1.0')
             | memory(results)
         ).execute()
 
@@ -350,7 +350,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_or_filter(self):
         results = []
         (
-            read('elastic', index='test_data', where='string == "a" or float == 3.0')
+            read('elastic', index='test_data', filter='string == "a" or float == 3.0')
             | memory(results)
         ).execute()
 
@@ -362,7 +362,7 @@ class ElasticTest(unittest.TestCase):
     def test_elastic_read_with_not_filter(self):
         results = []
         (
-            read('elastic', index='test_data', where='not(string == "h")')
+            read('elastic', index='test_data', filter='not(string == "h")')
             | memory(results)
         ).execute()
 

--- a/test/unit/adapters/elastic/test_elastic_query.py
+++ b/test/unit/adapters/elastic/test_elastic_query.py
@@ -4,26 +4,26 @@ elastic adapter query conversion unittests
 import unittest
 
 from robber import expect
-from flume.adapters.elastic.query import where_to_es_query
+from flume.adapters.elastic.query import filter_to_es_query
 from flume.exceptions import FlumineException
 
 
 class ElasticTest(unittest.TestCase):
 
     def test_default_filter_is_match_all(self):
-        expect(where_to_es_query(None)).to.eq({
+        expect(filter_to_es_query(None)).to.eq({
             'match_all': {}
         })
 
     def test_invalid_assignment_query(self):
         try:
-            expect(where_to_es_query('foo="bar"'))
+            expect(filter_to_es_query('foo="bar"'))
             raise Exception('previous statement should have failed')
         except FlumineException as exception:
-            expect(exception.message).to.contain('invalid where expression: foo="bar"')
+            expect(exception.message).to.contain('invalid filter expression: foo="bar"')
 
     def test_single_string_eq_query(self):
-        expect(where_to_es_query('foo=="bar"')).to.eq({
+        expect(filter_to_es_query('foo=="bar"')).to.eq({
             'constant_score': {
                 'filter': {
                     'term': {'foo': 'bar'}
@@ -32,7 +32,7 @@ class ElasticTest(unittest.TestCase):
         })
 
     def test_single_string_neq_query(self):
-        expect(where_to_es_query('foo!="bar"')).to.eq({
+        expect(filter_to_es_query('foo!="bar"')).to.eq({
             'constant_score': {
                 'filter': {
                     'not': {
@@ -43,7 +43,7 @@ class ElasticTest(unittest.TestCase):
         })
 
     def test_single_term_integer_query(self):
-        expect(where_to_es_query('foo==2')).to.eq({
+        expect(filter_to_es_query('foo==2')).to.eq({
             'constant_score': {
                 'filter': {
                     'term': {'foo': 2}
@@ -52,7 +52,7 @@ class ElasticTest(unittest.TestCase):
         })
 
     def test_single_and_query(self):
-        expect(where_to_es_query('foo==1 and fizz=="buzz"')).to.eq({
+        expect(filter_to_es_query('foo==1 and fizz=="buzz"')).to.eq({
             'constant_score': {
                 'filter': {
                     'bool': {
@@ -66,7 +66,7 @@ class ElasticTest(unittest.TestCase):
         })
 
     def test_single_or_query(self):
-        expect(where_to_es_query('foo==1 or fizz=="buzz"')).to.eq({
+        expect(filter_to_es_query('foo==1 or fizz=="buzz"')).to.eq({
             'constant_score': {
                 'filter': {
                     'bool': {
@@ -83,7 +83,7 @@ class ElasticTest(unittest.TestCase):
     def test_and_with_nested_or_query(self):
         query = 'foo==1 and (fizz=="buzz" or fizz=="bar")'
 
-        expect(where_to_es_query(query)).to.eq({
+        expect(filter_to_es_query(query)).to.eq({
             'constant_score': {
                 'filter': {
                     'bool': {
@@ -108,7 +108,7 @@ class ElasticTest(unittest.TestCase):
 
     def test_or_with_nested_and_query(self):
         query = 'foo==1 or (fizz=="buzz" and fizz=="bar")'
-        expect(where_to_es_query(query)).to.eq({
+        expect(filter_to_es_query(query)).to.eq({
             'constant_score': {
                 'filter': {
                     'bool': {


### PR DESCRIPTION
lets make all query arguments use the name filter which then matches 
the filter proc name which makes more sense since they are the same
thing expressed in two different ways

fixes #5 
