### PR TITLE
string interpolation for field values

### DIFF
--- a/flume/procs/put.py
+++ b/flume/procs/put.py
@@ -32,7 +32,12 @@ class put(node):
                     if isinstance(value, reducer):
                         value.update(point)
                         point[key] = value.result()
+
                     else:
-                        point[key] = value
+                        if isinstance(value, str) or isinstance(value, unicode):
+                            point[key] = value.format(**point.json())
+
+                        else:
+                            point[key] = value
 
             self.push(points)

--- a/flume/procs/reduce/core.py
+++ b/flume/procs/reduce/core.py
@@ -142,7 +142,11 @@ class reduce(node):
                         fields_copy[key] = value.result()
 
                     else:
-                        fields_copy[key] = value
+                        if isinstance(value, str) or isinstance(value, unicode):
+                            fields_copy[key] = value.format(**point.json())
+
+                        else:
+                            fields_copy[key] = value
 
                     results[by_key][key] = fields_copy[key]
 

--- a/test/unit/procs/reduce/test_reduce.py
+++ b/test/unit/procs/reduce/test_reduce.py
@@ -9,6 +9,37 @@ from flume import *
 
 class ReduceTest(unittest.TestCase):
 
+    def test_reduce_to_a_static_value(self):
+        results = []
+        (
+            emit(limit=5, every='0.001s')
+            | reduce(count=0)
+            | keep('count')
+            | memory(results)
+        ).execute()
+        expect(results).to.eq([{'count': 0}])
+
+    def test_reduce_field_with_interpolated_field_value(self):
+        results = []
+        (
+            emit(limit=5, every='0.001s')
+            | put(count=count())
+            | reduce(message='count is {count}')
+            | keep('message')
+            | memory(results)
+        ).execute()
+        expect(results).to.eq([{'message': 'count is 5'}])
+
+    def test_reduce_field_with_interpolated_time_value(self):
+        results = []
+        (
+            emit(limit=5, start='2016-01-01')
+            | reduce(message='last point at "{time}"')
+            | keep('message')
+            | memory(results)
+        ).execute()
+        expect(results).to.eq([{'message': 'last point at "2016-01-01T00:00:04.000Z"'}])
+
     def test_reduce_to_a_count(self):
         results = []
         (

--- a/test/unit/procs/test_put.py
+++ b/test/unit/procs/test_put.py
@@ -45,3 +45,31 @@ class PutTest(unittest.TestCase):
             {'foo': 1, 'fizz': 'buzz'},
             {'foo': 1, 'fizz': 'buzz'}
         ])
+
+    def test_put_field_value_interpolations(self):
+        results = []
+        (
+            emit(limit=3, start='2013-01-01')
+            | put(count=count(), message='this is line #{count}')
+            | remove('time', 'count')
+            | memory(results)
+        ).execute()
+        expect(results).to.eq([
+            {'message': 'this is line #1'},
+            {'message': 'this is line #2'},
+            {'message': 'this is line #3'}
+        ])
+
+    def test_put_time_value_interpolations(self):
+        results = []
+        (
+            emit(limit=3, start='2013-01-01')
+            | put(count=count(), message='this happened at "{time}"')
+            | remove('time', 'count')
+            | memory(results)
+        ).execute()
+        expect(results).to.eq([
+            {'message': 'this happened at "2013-01-01T00:00:00.000Z"'},
+            {'message': 'this happened at "2013-01-01T00:00:01.000Z"'},
+            {'message': 'this happened at "2013-01-01T00:00:02.000Z"'}
+        ])


### PR DESCRIPTION
with this change whenever you use the {xxx} notation within the string
value of a field being created in a `put` or `reduce` proc then flume
will attempt to replace the {xxx} with the value of the field in the
current point with the name xxx. If xxx is not found the string will
remain untouched.
