### PR TITLE
add array option to http write

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
 coverage==4.1
 docker-py==1.8.1
-Flask==0.10.1
 robber==1.0.1
 bunch==1.0.1
 mock==2.0.0


### PR DESCRIPTION
Added new array argument to http adapter so you can choose to write
arrays vs single objects out when using the write sink. Also reworked
the tests to not depend on Flask anymore
