### PR TITLE
move time field handling to read source

### DIFF
--- a/flume/adapters/elastic/node.py
+++ b/flume/adapters/elastic/node.py
@@ -25,14 +25,12 @@ class elastic(adapter):
                  type='metric',
                  host='localhost',
                  port=9200,
-                 time='time',
                  filter=None,
                  batch=1024):
         self.index = index
         self.type = type
         self.host = host
         self.port = port
-        self.time = time
         self.filter = filter
         self.batch = batch
         self.clients = {}
@@ -63,7 +61,6 @@ class elastic(adapter):
                                    query={'query': query, 'sort': ['time']},
                                    preserve_order=True):
             point = Point(**result['_source'])
-            point.time = moment.date(point[self.time])
             points.append(point)
 
             if len(points) > self.batch:

--- a/flume/adapters/http.py
+++ b/flume/adapters/http.py
@@ -48,7 +48,6 @@ class http(adapter):
                  url=None,
                  method='GET',
                  headers=None,
-                 time='time',
                  filter=None,
                  follow_link=True,
                  format=None,
@@ -59,7 +58,6 @@ class http(adapter):
         self.url = url
         self.method = method
         self.headers = headers
-        self.time = time
         self.filter = filter
         self.follow_link = follow_link
         self.cache = cache
@@ -108,13 +106,6 @@ class http(adapter):
             for point in data:
                 # convert to a flume Point
                 point = Point(**point)
-
-                if self.time in point:
-                    point.time = moment.date(point[self.time])
-
-                else:
-                    logger.warn('point missing time field "%s"' % self.time)
-
                 points.append(point)
 
             yield points

--- a/flume/adapters/stdio.py
+++ b/flume/adapters/stdio.py
@@ -24,36 +24,21 @@ class stdio(adapter):
     stdin = sys.stdin
 
     def __init__(self,
-                 time='time',
                  format='jsonl',
                  file=None,
                  **kwargs):
-        self.time = time
         self.streamer = streamers.get_streamer(format, **kwargs)
         self.file = file
 
-    def __read(self, stream):
-        for point in self.streamer.read(stream):
-            if self.time in point.keys():
-                point['time'] = moment.date(point[self.time])
-
-                if self.time != 'time':
-                    del point[self.time]
-
-                yield [Point(**point)]
-
-            else:
-                yield [Point(**point)]
-
     def read(self):
         if self.file is None:
-            for point in self.__read(stdio.stdin):
-                yield point
+            for point in self.streamer.read(stdio.stdin):
+                yield [Point(**point)]
 
         else:
             with open(self.file, 'r') as stream:
-                for point in self.__read(stream):
-                    yield point
+                for point in self.streamer.read(stream):
+                    yield [Point(**point)]
 
     def write(self, points):
         if self.file is None:

--- a/test/unit/adapters/test_stdio.py
+++ b/test/unit/adapters/test_stdio.py
@@ -6,6 +6,8 @@ import json
 import sys
 import unittest
 
+import mock
+
 from StringIO import StringIO
 from robber import expect
 
@@ -59,8 +61,9 @@ class StdioTest(unittest.TestCase):
             {"time": "2016-01-01T00:01:00.000Z", "foo": 2},
             {"time": "2016-01-01T00:02:00.000Z", "foo": 3}
         ])
-
-    def test_stdio_can_read_a_single_timeless_point_(self):
+    
+    @mock.patch('flume.logger.warn')
+    def test_stdio_can_read_a_single_timeless_point_(self, mock_warn):
         stdio.stdin = StringIO('{"foo": "bar"}')
         results = []
 
@@ -71,8 +74,10 @@ class StdioTest(unittest.TestCase):
         expect(results).to.eq([
             {"foo": "bar"}
         ])
+        expect(mock_warn.call_args).to.eq(mock.call('point missing time field "time"'))
 
-    def test_stdio_can_read_multiple_timeless_points(self):
+    @mock.patch('flume.logger.warn')
+    def test_stdio_can_read_multiple_timeless_points(self, mock_warn):
         stdio.stdin = StringIO('{"foo": 1}\n{"foo": 2}\n{"foo": 3}\n')
         results = []
 
@@ -84,6 +89,11 @@ class StdioTest(unittest.TestCase):
             {"foo": 1},
             {"foo": 2},
             {"foo": 3}
+        ])
+        expect(mock_warn.call_args_list).to.eq([
+            mock.call('point missing time field "time"'),
+            mock.call('point missing time field "time"'),
+            mock.call('point missing time field "time"')
         ])
 
     def test_stdio_can_read_multiple_points_with_custom_timefield(self):
@@ -157,7 +167,8 @@ class StdioTest(unittest.TestCase):
             'foo': 'bar'
         })
 
-    def test_stdio_can_write_a_multiple_timeless_points(self):
+    @mock.patch('flume.logger.warn')
+    def test_stdio_can_write_a_multiple_timeless_points(self, mock_warn):
         stdout = StringIO('')
         stdio.stdout = stdout
         (
@@ -179,4 +190,11 @@ class StdioTest(unittest.TestCase):
             {'count': 3},
             {'count': 4},
             {'count': 5}
+        ])
+        expect(mock_warn.call_args_list).to.eq([
+            mock.call('point missing time field "time"'),
+            mock.call('point missing time field "time"'),
+            mock.call('point missing time field "time"'),
+            mock.call('point missing time field "time"'),
+            mock.call('point missing time field "time"')
         ])


### PR DESCRIPTION
moved the `time` field management code into the `read` source since its 
handled the same way and not the responsibility of the adapter
