### PR TITLE
various random fixes

### DIFF
--- a/docs/adapters/stdio.md
+++ b/docs/adapters/stdio.md
@@ -13,6 +13,7 @@ following options available at this time:
 read('stdio',
      format='jsonl',
      file=None,
+     strip_ansi=False,
      time='time') | ...
 ```
 
@@ -20,6 +21,7 @@ Argument    | Description                                                       
 ----------- | --------------------------------------------------------------------------- | :---------
 format      | format specifier used to pick a different kind of [streamer](streamers/)    | No, default: `jsonl`
 file        | filename to read from, when not specified we read from STDIN                | No, default: `None`
+strip_ansi  | when set to `True` then all ANSI sequences are removed from the input       | No, default: `False`
 time        | field name that contains valid timestamp                                    | No, default: `time`
 
 ## write
@@ -31,6 +33,7 @@ following options available at this time:
 write('stdio',
       format='jsonl',
       file=None,
+      append=False,
       time='time') | ...
 ```
 
@@ -38,6 +41,7 @@ Argument    | Description                                                       
 ----------- | --------------------------------------------------------------------------- | :---------
 format      | format specifier used to pick a different kind of [streamer](streamers/)    | No, default: `jsonl`
 file        | filename to write to, when not specified we read from STDOUT                | No, default: `None`
+append      | boolean that specifies if we should append or not to any existing output    | No, default: `False`
 time        | field name that contains valid timestamp                                    | No, default: `time`
 
 

--- a/docs/adapters/streamers/csv.md
+++ b/docs/adapters/streamers/csv.md
@@ -9,6 +9,8 @@ No arguments exposed at this point for read operations.
 
 ## write
 
-Argument | Description                                               | Required?
--------- | --------------------------------------------------------- | :---------
-headers  | boolean used to specify to print or not print the headers | No, default: `True`
+Argument          | Description                                                                    | Required?
+----------------- | ------------------------------------------------------------------------------ | :---------
+headers           | boolean used to specify to print or not print the headers                      | No, default: `True`
+delimiter         | delimiter character to use when reading the data                               | No, defualt: `,`
+ignore_whitespace | boolean used to specify if any preceding/trailing whitespace should be ignored | No, default: `False`

--- a/flume/adapters/stdio.py
+++ b/flume/adapters/stdio.py
@@ -1,6 +1,7 @@
 """
 stdio adapter
 """
+import re
 import sys
 
 from flume.adapters.adapter import adapter
@@ -15,21 +16,36 @@ class InputStream(object):
     the input to stream line by line and not block the pipeline.
     """
 
-    def __init__(self, file):
-        self.file = file
+    def __init__(self, stream, strip_ansi=False):
+        self.stream = stream 
+        self.strip_ansi = strip_ansi
+
+    def __remove_ansi(self, line):
+        if line is None:
+            return None
+
+        return re.sub(r'\x1b[^A-Za-z]*[A-Za-z]', '', line)
 
     def read(self, size=1024):
-        return self.file.read(size=1024)
+        if self.strip_ansi:
+            return self.__remove_ansi(self.stream.read(size))
+
+        else:
+            return self.stream.read(size)
 
     def readlines(self):
 
         while True:
-            line = self.file.readline()
+            line = self.stream.readline()
 
             if not line:
                 break
 
-            yield line
+            if self.strip_ansi:
+                yield self.__remove_ansi(line)
+
+            else:
+                yield line
 
 class stdio(adapter):
     """
@@ -48,18 +64,24 @@ class stdio(adapter):
     def __init__(self,
                  format='jsonl',
                  file=None,
+                 append=False,
+                 strip_ansi=False,
                  **kwargs):
         self.streamer = streamers.get_streamer(format, **kwargs)
         self.file = file
+        self.append = append
+        self.strip_ansi = strip_ansi
 
     def read(self):
         if self.file is None:
-            for point in self.streamer.read(InputStream(stdio.stdin)):
+            for point in self.streamer.read(InputStream(stdio.stdin,
+                                                        strip_ansi=self.strip_ansi)):
                 yield [Point(**point)]
 
         else:
             with open(self.file, 'r') as stream:
-                stream = InputStream(stream)
+                stream = InputStream(stream,
+                                     strip_ansi=self.strip_ansi)
                 for point in self.streamer.read(stream):
                     yield [Point(**point)]
 
@@ -68,7 +90,13 @@ class stdio(adapter):
             self.streamer.write(stdio.stdout, points)
 
         else:
-            with open(self.file, 'a') as stream:
+            if self.append:
+                mode = 'a'
+
+            else:
+                mode = 'w'
+
+            with open(self.file, mode) as stream:
                 self.streamer.write(stream, points)
 
     def eof(self):

--- a/flume/adapters/streamers/csver.py
+++ b/flume/adapters/streamers/csver.py
@@ -9,13 +9,19 @@ from flume import Point
 
 class CSV(Streamer):
 
-    def __init__(self, headers=True):
+    def __init__(self,
+                 headers=True,
+                 delimiter=',',
+                 ignore_whitespace=True):
         self.writer = None
         self.headers = headers
+        self.delimiter = delimiter
+        self.ignore_whitespace = ignore_whitespace
 
     def read(self, stream):
-        # XXX: expose the delimiter, quotechar...etc.
-        reader = csv.DictReader(stream)
+        reader = csv.DictReader(stream.readlines(),
+                                delimiter=self.delimiter,
+                                skipinitialspace=self.ignore_whitespace)
 
         for point in reader:
             # XXX: buffer N points before pushing out ? 

--- a/flume/cli.py
+++ b/flume/cli.py
@@ -1,6 +1,5 @@
 """
-flume command line utility
-"""
+flume command line utility """
 import imp
 import logging
 import os

--- a/test/unit/adapters/test_stdio.py
+++ b/test/unit/adapters/test_stdio.py
@@ -4,6 +4,7 @@ http adapter unittests
 
 import json
 import sys
+import tempfile
 import unittest
 
 import mock
@@ -33,7 +34,7 @@ class StdioTest(unittest.TestCase):
         ).execute()
         expect(results).to.eq([])
 
-    def test_stdio_can_read_a_single_point_(self):
+    def test_stdio_can_read_a_single_point(self):
         stdio.stdin = StringIO('{"time": "2016-01-01T00:00:00.000Z", "foo": "bar"}')
         results = []
 
@@ -44,6 +45,72 @@ class StdioTest(unittest.TestCase):
         expect(results).to.eq([
             {"time": "2016-01-01T00:00:00.000Z", "foo": "bar"}
         ])
+
+    def test_stdio_can_read_and_strip_ansi_sequences_from_terminal(self):
+        stdio.stdin = StringIO('''\033[1;32m pid cmd cpu\033[0m
+1 init 0.0
+2 bash 2.0
+25 blah 3.0''')
+        results = []
+
+        (
+            read('stdio', format='csv', delimiter=' ', strip_ansi=True)
+            | memory(results)
+        ).execute()
+        expect(results).to.eq([
+            {'pid': '1', 'cmd': 'init', 'cpu': '0.0'},
+            {'pid': '2', 'cmd': 'bash', 'cpu': '2.0'},
+            {'pid': '25', 'cmd': 'blah', 'cpu': '3.0'}
+        ])
+
+    def test_stdio_can_read_and_strip_ansi_sequences_from_jsonl(self):
+        stdio.stdin = StringIO('{"time": "2016-01-01T00:00:00.000Z", "foo": "\033[1;32mbar\033[0m"}')
+        results = []
+
+        (
+            read('stdio', format='jsonl', strip_ansi=True)
+            | memory(results)
+        ).execute()
+        expect(results).to.eq([
+            {"time": "2016-01-01T00:00:00.000Z", "foo": "bar"}
+        ])
+
+    def test_stdio_can_read_and_strip_ansi_sequences_from_json(self):
+        stdio.stdin = StringIO('[{"time": "2016-01-01T00:00:00.000Z", "foo": "\033[1;32mbar\033[0m"}]')
+        results = []
+
+        (
+            read('stdio', format='json', strip_ansi=True)
+            | memory(results)
+        ).execute()
+        expect(results).to.eq([
+            {"time": "2016-01-01T00:00:00.000Z", "foo": "bar"}
+        ])
+
+    def test_stdio_can_read_and_not_strip_ansi_sequences_from_json(self):
+        stdio.stdin = StringIO('[{"time": "2016-01-01T00:00:00.000Z", "foo": "\033[1;32mbar\033[0m"}]')
+        results = []
+
+        (
+            read('stdio', format='json')
+            | memory(results)
+        ).execute()
+        expect(results).to.eq([
+            {"time": "2016-01-01T00:00:00.000Z", "foo": "\033[1;32mbar\033[0m"}
+        ])
+
+    def test_stdio_can_read_a_single_point(self):
+        stdio.stdin = StringIO('{"time": "2016-01-01T00:00:00.000Z", "foo": "bar"}')
+        results = []
+
+        (
+            read('stdio', format='jsonl')
+            | memory(results)
+        ).execute()
+        expect(results).to.eq([
+            {"time": "2016-01-01T00:00:00.000Z", "foo": "bar"}
+        ])
+
 
     def test_stdio_can_read_multiple_points(self):
         stdio.stdin = StringIO('{"time": "2016-01-01T00:00:00.000Z", "foo": 1}\n' +
@@ -61,8 +128,8 @@ class StdioTest(unittest.TestCase):
             {"time": "2016-01-01T00:01:00.000Z", "foo": 2},
             {"time": "2016-01-01T00:02:00.000Z", "foo": 3}
         ])
-    
-    def test_stdio_can_read_a_single_timeless_point_(self):
+
+    def test_stdio_can_read_a_single_timeless_point(self):
         stdio.stdin = StringIO('{"foo": "bar"}')
         results = []
 
@@ -181,4 +248,77 @@ class StdioTest(unittest.TestCase):
             {'count': 3},
             {'count': 4},
             {'count': 5}
+        ])
+
+    def test_stdio_can_read_a_single_point_from_a_file(self):
+        _, tmpfile = tempfile.mkstemp()
+
+        with open(tmpfile, 'w') as output:
+            output.write('{"time": "2016-01-01T00:00:00.000Z", "foo": "bar"}')
+
+        results = []
+
+        (
+            read('stdio', file=tmpfile)
+            | memory(results)
+        ).execute()
+        expect(results).to.eq([
+            {"time": "2016-01-01T00:00:00.000Z", "foo": "bar"}
+        ])
+
+    def test_stdio_can_write_a_single_point_to_a_file(self):
+        _, tmpfile = tempfile.mkstemp()
+
+        (
+            emit(limit=1, start='2016-01-01')
+            | write('stdio', file=tmpfile)
+        ).execute()
+
+        with open(tmpfile, 'r') as tmp_input:
+            expect(json.loads(tmp_input.read())).to.eq({
+                'time': '2016-01-01T00:00:00.000Z'
+            })
+
+
+    def test_stdio_can_write_override_single_point_to_a_file(self):
+        _, tmpfile = tempfile.mkstemp()
+
+        (
+            emit(limit=1, start='2015-01-01')
+            | write('stdio', file=tmpfile)
+        ).execute()
+
+        (
+            emit(limit=1, start='2016-01-01')
+            | write('stdio', file=tmpfile, append=False)
+        ).execute()
+
+        with open(tmpfile, 'r') as tmp_input:
+            expect(json.loads(tmp_input.read())).to.eq({
+                'time': '2016-01-01T00:00:00.000Z'
+            })
+
+    def test_stdio_can_write_append_multiple_points_to_a_file(self):
+        _, tmpfile = tempfile.mkstemp()
+
+        (
+            emit(limit=1, start='2015-01-01')
+            | write('stdio', file=tmpfile)
+        ).execute()
+
+        (
+            emit(limit=1, start='2016-01-01')
+            | write('stdio', file=tmpfile, append=True)
+        ).execute()
+        
+        results = []
+
+        (
+            read('stdio', file=tmpfile)
+            | memory(results)
+        ).execute()
+
+        expect(results).to.eq([
+            {'time': '2015-01-01T00:00:00.000Z'},
+            {'time': '2016-01-01T00:00:00.000Z'}
         ])


### PR DESCRIPTION
fixes #20

added new `strip_ansi` to the `read` source and `append` option to the
`write` sink.

removed silly debug flag that wasn't doing anything

added a bunch of missing `stdio` unit tests

added `delimiter` and `ignore_whitespace` options to the CSV parser
which means it can be used to read other similar formats
