### PR TITLE
new `seq` proc

### DIFF
--- a/docs/procs/index.md
+++ b/docs/procs/index.md
@@ -13,6 +13,7 @@ and you can always create your own.
  * [keep](keep/)
  * [put](put/)
  * [remove](remove/)
+ * [seq](seq/)
  * [sort](sort/)
  * [tail](tail/)
  * [union](union/)

--- a/docs/procs/seq.md
+++ b/docs/procs/seq.md
@@ -1,0 +1,44 @@
+# seq
+
+The `seq` proc is used to serialize the execution of N **flume** pipelines so
+that they execute in the same order that you've passed them to the `seq` proc.
+
+```python
+...  | seq(*pipelines) | ...
+```
+
+Argument   | Description                                     | Required?
+-----------| ----------------------------------------------- | :---------
+*pipelines | list of **flume** pipelines to execute serially | Yes
+
+
+# serialize the execution of two emits
+
+```python
+from flume import *
+
+(
+    seq(emit(limit=5, every='1s'),
+        emit(limit=5, every='0.5s'))
+    | write('stdio')
+).execute()
+```
+
+The above would produce the output:
+
+```json
+{"time": "2016-08-12T22:03:06.156Z"}
+{"time": "2016-08-12T22:03:07.156Z"}
+{"time": "2016-08-12T22:03:08.156Z"}
+{"time": "2016-08-12T22:03:09.156Z"}
+{"time": "2016-08-12T22:03:10.156Z"}
+{"time": "2016-08-12T22:03:11.167Z"}
+{"time": "2016-08-12T22:03:11.667Z"}
+{"time": "2016-08-12T22:03:12.167Z"}
+{"time": "2016-08-12T22:03:12.667Z"}
+{"time": "2016-08-12T22:03:13.167Z"}
+```
+
+And you'll see how your stream will emit 1 point per second for 5s and then
+another 5 points in half that time. Which is a small example of how the `seq`
+proc can be useful.

--- a/flume/core.py
+++ b/flume/core.py
@@ -206,7 +206,7 @@ class node(object):
         push the provided points to the outputs of this node so that other
         nodes downstream can receive it
         """
-        
+
         if isinstance(points, Point):
             points = [points]
 

--- a/flume/procs/__init__.py
+++ b/flume/procs/__init__.py
@@ -13,6 +13,8 @@ from flume.procs.filter import filter
 # pylint: disable=redefined-builtin
 from flume.procs.reduce import reduce
 
+from flume.procs.seq import seq
+
 from flume.procs.reorder import reorder
 from flume.procs.sort import sort
 

--- a/flume/procs/seq.py
+++ b/flume/procs/seq.py
@@ -1,0 +1,41 @@
+"""
+seq proc
+"""
+from flume import node, queue
+
+class pipe(node):
+
+    def loop(self):
+        while self.running:
+            points = self.pull()
+            self.push(points)
+
+    def push(self, points):
+        node.push(self, [point for point in points if point != self.EOF])
+
+class seq(node):
+
+    name = 'seq'
+
+    def __init__(self, *pipelines):
+        node.__init__(self)
+        self.pipelines = pipelines
+
+    def loop(self):
+        for pipeline in self.pipelines:
+            outputs = list(self.outputs)
+
+            node.init_node(pipeline,
+                           inputs=None,
+                           outputs=[queue()],
+                           parent=None,
+                           source=None)
+
+            connector = pipe()
+            node.init_node(connector,
+                           inputs=pipeline.outputs,
+                           outputs=outputs,
+                           parent=pipeline,
+                           source=None)
+
+            connector.execute(wait=True)

--- a/flume/sources/emit.py
+++ b/flume/sources/emit.py
@@ -114,7 +114,7 @@ class emit(node):
                                     1,
                                     push_point,
                                     (current_time, count))
-
+            
                 scheduler.enter(every_seconds,
                                 1,
                                 push_point,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ pages:
             - 'maximum': 'procs/reduce/reducers/maximum.md'
             - 'minimum': 'procs/reduce/reducers/minimum.md'
         - 'remove': 'procs/remove.md'
+        - 'seq': 'procs/seq.md'
         - 'sort': 'procs/sort.md'
         - 'tail': 'procs/tail.md'
         - 'union': 'procs/union.md'

--- a/test/unit/procs/test_seq.py
+++ b/test/unit/procs/test_seq.py
@@ -1,0 +1,41 @@
+"""
+seq proc unittests
+"""
+import unittest
+
+from robber import expect
+from flume import *
+
+
+class SeqTest(unittest.TestCase):
+
+    def test_seq_can_chain_two_historical_streams(self):
+        results = []
+        (
+            seq(emit(limit=3, start='2016-01-01T00:00:00.000Z'),
+                emit(limit=3, start='2016-01-01T00:00:03.000Z'))
+            | put(value=count())
+            | memory(results)
+        ).execute()
+        expect(results).to.eq([
+            {'time': '2016-01-01T00:00:00.000Z', 'value': 1},
+            {'time': '2016-01-01T00:00:01.000Z', 'value': 2},
+            {'time': '2016-01-01T00:00:02.000Z', 'value': 3},
+            {'time': '2016-01-01T00:00:03.000Z', 'value': 4},
+            {'time': '2016-01-01T00:00:04.000Z', 'value': 5},
+            {'time': '2016-01-01T00:00:05.000Z', 'value': 6}
+        ])
+
+
+    def test_seq_can_chain_two_live_streams(self):
+        results = []
+        (
+            seq(emit(limit=3, every='0.1s'),
+                emit(limit=3, every='0.1s'))
+            | reduce(count=count())
+            | keep('count')
+            | memory(results)
+        ).execute()
+        expect(results).to.eq([
+            {'count': 6}
+        ])


### PR DESCRIPTION
`seq` proc can be used to serialize multiple pipelines into a single
stream where each is executed in turn.
