### PR TITLE
optimized count, maximum, minimum in es adapter

### DIFF
--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -71,9 +71,4 @@ Have a look at how we implemented the `optimize` method for
 [elastic](https://github.com/rlgomes/flume/blob/master/flume/adapters/elastic/node.py)
 and 
 [stdio](https://github.com/rlgomes/flume/blob/master/flume/adapters/stdio.py)
-to get a simple view of how optimization can be done. We'll have more optimizations
-around doing counts and filters coming soon...
-
-
-
-
+to get a simple view of how optimization can be done.

--- a/flume/cli.py
+++ b/flume/cli.py
@@ -20,10 +20,16 @@ VERSION = open(os.path.join(os.path.dirname(flume.__file__),
 
 @click.command()
 @click.version_option(version=VERSION)
-@click.option('--debug', '-d', count=True, help='debug mode')
+@click.option('--debug', '-d',
+              count=True,
+              help='debug mode')
+@click.option('--optimize/--no-optimize',
+              default=True,
+              help='turns read optimizations on/off, default: on')
 @click.argument('program')
 def main(program=None,
-         debug=False):
+         debug=False,
+         optimize=True):
     """
     simple command line entry point for executing flume programs
     """
@@ -47,7 +53,8 @@ def main(program=None,
                 for thing in dir(module):
                     globals()[thing] = module.__dict__[thing]
 
-    eval(program, globals(), locals()).execute(loglevel=loglevel)
+    eval(program, globals(), locals()).execute(loglevel=loglevel,
+                                               optimize=optimize)
 
 if __name__ == '__main__':
     main()

--- a/flume/sinks/write.py
+++ b/flume/sinks/write.py
@@ -36,6 +36,6 @@ class write(sink):
                     buffered = buffered[self.batch:]
 
         if len(buffered) > 0:
-            self.write(buffered[:self.batch])
+            self.write(buffered)
 
         self.instance.eof()

--- a/flume/sources/read.py
+++ b/flume/sources/read.py
@@ -26,7 +26,7 @@ class read(node):
         self.read = self.instance.read
 
     def loop(self):
-        if self.child is not None:
+        if self.child is not None and self.config.optimize:
             self.instance.optimize(self.child)
 
         for points in self.read():


### PR DESCRIPTION
fixes #39

with this we'll have a tremendous performance boost since since these
reductions are done in the storage layer and we don't need to pull
thousands of data points all the way into the **flume** runtime engine
in order to calculate the same things.

As an example of the performance boost:

``` bash
rlgomes@t460s> flume "emit(limit=100000, start='1970-01-01') |
put(count=count()) | write('elastic', index='test', batch=1024)"
2016-09-06 21:39:50 $?=0 pwd=/home/rlgomes/workspace/python/flume
venv=env branch=(no duration=38.256s

rlgomes@t460s> flume --no-optimize "read('elastic', index='test') |
reduce(count=count()) | write('stdio')"
{"count": 100000, "time": "1970-01-01T00:00:00.000Z"}
2016-09-06 21:41:26 $?=0 pwd=/home/rlgomes/workspace/python/flume
venv=env branch=(no duration=72.940s

rlgomes@t460s> flume "read('elastic', index='test') |
reduce(count=count()) | write('stdio')"
{"count": 100000, "time": "1970-01-01T00:00:00.000Z"}
2016-09-06 21:42:07 $?=0 pwd=/home/rlgomes/workspace/python/flume
venv=env branch=(no duration=.473s

rlgomes@t460s> flume --no-optimize "read('elastic', index='test') |
reduce(max=maximum('count')) | write('stdio')"
{"max": 100000, "time": "1970-01-01T00:00:00.000Z"}
2016-09-06 21:43:21 $?=0 pwd=/home/rlgomes/workspace/python/flume
venv=env branch=(no duration=57.814s

rlgomes@t460s> flume "read('elastic', index='test') |
reduce(max=maximum('count')) | write('stdio')"
{"max": 100000.0, "time": "1970-01-01T00:00:00.000Z"}
2016-09-06 21:44:17 $?=0 pwd=/home/rlgomes/workspace/python/flume
venv=env branch=(no duration=.439s

rlgomes@t460s> flume --no-optimize "read('elastic', index='test') |
reduce(min=minimum('count')) | write('stdio')"
{"time": "1970-01-01T00:00:00.000Z", "min": 1}
2016-09-06 21:45:16 $?=0 pwd=/home/rlgomes/workspace/python/flume
venv=env branch=(no duration=44.500s

rlgomes@t460s> flume "read('elastic', index='test') |
reduce(min=minimum('count')) | write('stdio')"
{"min": 1.0, "time": "1970-01-01T00:00:00.000Z"}
2016-09-06 21:45:24 $?=0 pwd=/home/rlgomes/workspace/python/flume
venv=env branch=(no duration=.381s
```

The above example is just when applied to 100K data points and yet the
different is anywhere from 117x to 154x faster with the new
optimizations.
